### PR TITLE
build: prepare for test matrix

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
     needs:
       - prepare-environment
       - build-development-image
-    uses: open-space-collective/open-space-toolkit/.github/workflows/test.yml@users/alexliang/test-matrix # TBM: demo purposes only
+    uses: open-space-collective/open-space-toolkit/.github/workflows/test.yml@main
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -55,7 +55,7 @@ jobs:
     needs:
       - prepare-environment
       - build-development-image
-    uses: open-space-collective/open-space-toolkit/.github/workflows/test.yml@main
+    uses: open-space-collective/open-space-toolkit/.github/workflows/test.yml@users/alexliang/test-matrix # TBM: demo purposes only
     with:
       project_name: ${{ needs.prepare-environment.outputs.project_name }}
       project_version: ${{ needs.prepare-environment.outputs.project_version }}

--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 
 .PHONY: test-unit-python-standalone
 
-ci-test-python: ## Run Python unit tests. Assumes the dev image has already been built, AND that bindings have been built and are avaliable at `packages/python`
+ci-test-python: ## Run Python unit tests. Assumes the dev image has already been built, AND that bindings have been built and are available at `packages/python`
 
 	@ echo "Running Python unit tests..."
 

--- a/Makefile
+++ b/Makefile
@@ -542,6 +542,23 @@ test-unit-python-standalone: ## Run Python unit tests (standalone)
 
 .PHONY: test-unit-python-standalone
 
+ci-test-python: ## Run Python unit tests. Assumes the dev image has already been built, AND that bindings have been built and are avaliable at `packages/python`
+
+	@ echo "Running Python unit tests..."
+
+	docker run \
+	--rm \
+	--volume="$(CURDIR):/app:delegated" \
+	--volume="/app/build" \
+	--workdir=/app/build \
+	$(docker_development_image_repository):$(docker_image_version) \
+	/bin/bash -c "python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} --find-links packages/python open_space_toolkit_${project_name} \
+	&& python${test_python_version} -m pip install --root-user-action=ignore --target=${test_python_directory} plotly pandas \
+	&& cd ${test_python_directory}/ostk/$(project_name)/ \
+	&& python${test_python_version} -m pytest -sv ."
+
+.PHONY: ci-test-python
+
 test-coverage: ## Run test coverage cpp
 
 	@ echo "Running coverage tests..."


### PR DESCRIPTION
Adds a new Makefile directive to be used in CI to facilitate unit testing multiple Python versions. This should be merged BEFORE https://github.com/open-space-collective/open-space-toolkit/pull/144, and will only kick in after the latter is merged.