### PR TITLE
build: bump ostk astrodynamics to ~15.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,9 +340,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics [11.x.y]
+### Open Space Toolkit ▸ Physics [12.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "11" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "12" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 
@@ -350,9 +350,9 @@ IF (NOT OpenSpaceToolkitPhysics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Astrodynamics [14.x.y]
+### Open Space Toolkit ▸ Astrodynamics [15.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitAstrodynamics" "14" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitAstrodynamics" "15" REQUIRED)
 
 IF (NOT OpenSpaceToolkitAstrodynamics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,5 +3,5 @@
 open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=11.1
-open-space-toolkit-astrodynamics~=14.0
+open-space-toolkit-physics~=12.0
+open-space-toolkit-astrodynamics~=15.0

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="11"
+ARG OSTK_PHYSICS_MAJOR="12"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json
@@ -124,7 +124,7 @@ RUN mkdir -p /tmp/open-space-toolkit-physics \
 ## Open Space Toolkit ▸ Astrodynamics
 
 ARG TARGETPLATFORM
-ARG OSTK_ASTRODYNAMICS_MAJOR="14"
+ARG OSTK_ASTRODYNAMICS_MAJOR="15"
 
 ## Force an image rebuild when new Astrodynamics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-astrodynamics/git/matching-refs/tags/${OSTK_ASTRODYNAMICS_MAJOR} /tmp/open-space-toolkit-astrodynamics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
	- Updated Open Space Toolkit Physics dependency from version 11.x to 12.x
	- Updated Open Space Toolkit Astrodynamics dependency from version 14.x to 15.x
	- Updated Python requirements and Docker development image to reflect new library versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->