### PR TITLE
build: bump ostk astrodynamics to 16.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -350,9 +350,9 @@ IF (NOT OpenSpaceToolkitPhysics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Astrodynamics [15.x.y]
+### Open Space Toolkit ▸ Astrodynamics [16.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitAstrodynamics" "15" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitAstrodynamics" "16" REQUIRED)
 
 IF (NOT OpenSpaceToolkitAstrodynamics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -4,4 +4,4 @@ open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
 open-space-toolkit-physics~=12.0
-open-space-toolkit-astrodynamics~=15.0
+open-space-toolkit-astrodynamics~=16.0

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -124,7 +124,7 @@ RUN mkdir -p /tmp/open-space-toolkit-physics \
 ## Open Space Toolkit ▸ Astrodynamics
 
 ARG TARGETPLATFORM
-ARG OSTK_ASTRODYNAMICS_MAJOR="15"
+ARG OSTK_ASTRODYNAMICS_MAJOR="16"
 
 ## Force an image rebuild when new Astrodynamics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-astrodynamics/git/matching-refs/tags/${OSTK_ASTRODYNAMICS_MAJOR} /tmp/open-space-toolkit-astrodynamics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependencies to require version 16 of the Open Space Toolkit Astrodynamics package across build configuration, Python requirements, and development Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->