### PR TITLE
build: add BUILD_WITHOUT_DEPRACATED_DECLARATIONS CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,6 @@ SET (PROJECT_VENDOR_NAME "Open Space Collective")
 SET (PROJECT_VENDOR_CONTACT "contact@open-space-collective.org")
 SET (PROJECT_VENDOR_URL "open-space-collective.org")
 
-
 ## Project Options
 
 OPTION (BUILD_SHARED_LIBRARY "Build shared library." ON)
@@ -25,6 +24,7 @@ OPTION (BUILD_WITH_DEBUG_SYMBOLS "Build with debug symbols" ON)
 OPTION (BUILD_WITH_CXX_17 "Build with C++ 17 support." OFF)
 OPTION (BUILD_WITH_BOOST_STACKTRACE "Build with Boost Stacktrace instead of stacktrace basic" ON)
 OPTION (BUILD_WITH_BOOST_STATIC "Build with Boost Static lib" ON)
+OPTION (BUILD_WITHOUT_DEPRECATED_DECLARATION_WARNINGS "Build without deprecated declaration warnings" OFF)
 
 ## Setup
 
@@ -179,6 +179,14 @@ SET (CMAKE_CXX_EXTENSIONS OFF)
 IF (BUILD_WITH_DEBUG_SYMBOLS)
 
     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
+
+ENDIF ()
+
+### Warnings
+
+IF (BUILD_WITHOUT_DEPRECATED_DECLARATION_WARNINGS)
+
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 ENDIF ()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to suppress warnings about deprecated declarations during the build process. This can be enabled through a new build setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->