### PR TITLE
build: bump ostk-physics to 13.X and ostk-astrodynamics to 16.6.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,9 +348,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics [12.x.y]
+### Open Space Toolkit ▸ Physics [13.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "12" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "13" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -3,5 +3,5 @@
 open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
-open-space-toolkit-physics~=12.0
-open-space-toolkit-astrodynamics~=16.0
+open-space-toolkit-physics~=13.0
+open-space-toolkit-astrodynamics>=16.6.2

--- a/bindings/python/requirements.txt
+++ b/bindings/python/requirements.txt
@@ -4,4 +4,4 @@ open-space-toolkit-core~=5.0
 open-space-toolkit-io~=4.0
 open-space-toolkit-mathematics~=4.3
 open-space-toolkit-physics~=13.0
-open-space-toolkit-astrodynamics>=16.6.2
+open-space-toolkit-astrodynamics~=16.6,>=16.6.2

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="12"
+ARG OSTK_PHYSICS_MAJOR="13"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency requirements to use OpenSpaceToolkitPhysics version 13.
  * Increased minimum required version of open-space-toolkit-astrodynamics to 16.6.2 in Python requirements.
  * Updated Docker development environment to use OpenSpaceToolkitPhysics version 13.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->