### PR TITLE
build: bump to ostk-physics 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,9 +348,9 @@ IF (NOT OpenSpaceToolkitMathematics_FOUND)
 
 ENDIF ()
 
-### Open Space Toolkit ▸ Physics [13.x.y]
+### Open Space Toolkit ▸ Physics [14.x.y]
 
-FIND_PACKAGE ("OpenSpaceToolkitPhysics" "13" REQUIRED)
+FIND_PACKAGE ("OpenSpaceToolkitPhysics" "14" REQUIRED)
 
 IF (NOT OpenSpaceToolkitPhysics_FOUND)
 

--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -25,7 +25,7 @@ dependencies = [
     "open-space-toolkit-core~=5.0",
     "open-space-toolkit-io~=4.0",
     "open-space-toolkit-mathematics~=4.3",
-    "open-space-toolkit-physics~=13.0",
+    "open-space-toolkit-physics~=14.0",
     "open-space-toolkit-astrodynamics~=17.0",
 ] 
 

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -107,7 +107,7 @@ RUN mkdir -p /tmp/open-space-toolkit-mathematics \
 ## Open Space Toolkit ▸ Physics
 
 ARG TARGETPLATFORM
-ARG OSTK_PHYSICS_MAJOR="13"
+ARG OSTK_PHYSICS_MAJOR="14"
 
 ## Force an image rebuild when new Physics minor or patch versions are detected
 ADD https://api.github.com/repos/open-space-collective/open-space-toolkit-physics/git/matching-refs/tags/${OSTK_PHYSICS_MAJOR} /tmp/open-space-toolkit-physics/versions.json


### PR DESCRIPTION
Release notes: https://github.com/open-space-collective/open-space-toolkit-physics/releases/tag/14.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Open Space Toolkit Physics dependency from version 13.x to 14.x.
  * Updated Python package and development container configurations to use Physics 14.x.
  * Development builds and container images will now use the newer Physics libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->