### PR TITLE
chore: don't overwrite devcontainer venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,6 +317,7 @@ start-development-no-link: build-development-image-non-root ## Start development
 		-it \
 		--rm \
 		--volume="$(CURDIR):/app:delegated" \
+		--volume="/app/bindings/python/.venv" \
 		--volume="$(HOME)/.ssh:/home/$(dev_username)/.ssh:ro" \
 		--volume="$(HOME)/.gitconfig:/home/$(dev_username)/.gitconfig:ro" \
 		--workdir=/app/build \


### PR DESCRIPTION
see https://github.com/open-space-collective/open-space-toolkit-astrodynamics/pull/704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the non-root development container configuration to provide an additional Python virtual environment volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->