### PR TITLE
build: migrate python bindings from pybind11 to nanobind

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -27,6 +27,7 @@ SET (CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/tools/cmake")
 ### Policies
 
 CMAKE_POLICY (SET "CMP0048" NEW)
+CMAKE_POLICY (SET "CMP0063" NEW)  # honour visibility properties on static libraries
 
 ### Options
 
@@ -69,6 +70,39 @@ MACRO (FIND_PYTHON version)
     ENDIF ()
 ENDMACRO ()
 
+### Function stripping a built python module
+
+# Replaces pybind11's `pybind11_strip`, which nanobind has no equivalent of.
+
+FUNCTION (PY_STRIP name)
+    IF (CMAKE_STRIP)
+        ADD_CUSTOM_COMMAND (TARGET ${name} POST_BUILD COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${name}>)
+    ENDIF ()
+ENDFUNCTION ()
+
+### Function building the nanobind runtime library for one python version
+
+FUNCTION (NB_ADD_LIBRARY version)
+    SET (target "nanobind-static-${version}")
+
+    IF (TARGET ${target})
+        RETURN ()
+    ENDIF ()
+
+    ADD_LIBRARY (${target} STATIC EXCLUDE_FROM_ALL ${NANOBIND_SOURCES})
+    TARGET_INCLUDE_DIRECTORIES (${target} SYSTEM PUBLIC "${nanobind_SOURCE_DIR}/include")
+    TARGET_INCLUDE_DIRECTORIES (${target} PRIVATE "${nanobind_SOURCE_DIR}/ext/robin_map/include")
+    TARGET_LINK_LIBRARIES (${target} PUBLIC python${version}::headers)
+    TARGET_COMPILE_FEATURES (${target} PUBLIC cxx_std_17)
+    # Python's C API type-puns heavily.
+    TARGET_COMPILE_OPTIONS (${target} PRIVATE "-fno-strict-aliasing")
+    SET_TARGET_PROPERTIES (${target} PROPERTIES
+                          POSITION_INDEPENDENT_CODE ON
+                          C_VISIBILITY_PRESET hidden
+                          CXX_VISIBILITY_PRESET hidden
+    )
+ENDFUNCTION ()
+
 ### Function to grab python extension and use for target
 
 FUNCTION (PY_EXTENSION name version)
@@ -88,8 +122,10 @@ FUNCTION (PY_ADD_MODULE NAME)
     CMAKE_PARSE_ARGUMENTS (PARSE "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     SET (PYTHON_VERSION ${PARSE_PYTHON_VERSION})
 
+    NB_ADD_LIBRARY (${PYTHON_VERSION})
+
     ADD_LIBRARY (${NAME} MODULE ${PARSE_UNPARSED_ARGUMENTS})
-    PYBIND11_STRIP (${NAME})
+    PY_STRIP (${NAME})
     PY_EXTENSION (${NAME} ${PYTHON_VERSION})
 
     # Source Code
@@ -99,7 +135,10 @@ FUNCTION (PY_ADD_MODULE NAME)
     TARGET_INCLUDE_DIRECTORIES (${NAME} PUBLIC "${PROJECT_SOURCE_DIR}/src")
 
     # Pybind11/Python Headers
-    TARGET_LINK_LIBRARIES (${NAME} PRIVATE pybind11::module pybind11::lto python${PYTHON_VERSION}::headers)
+    TARGET_LINK_LIBRARIES (${NAME} PRIVATE "nanobind-static-${PYTHON_VERSION}" python${PYTHON_VERSION}::headers)
+    TARGET_COMPILE_OPTIONS (${NAME} PRIVATE "-fno-strict-aliasing")
+    # Trade nanobind's verbose assertion messages for a smaller binary.
+    TARGET_COMPILE_DEFINITIONS (${NAME} PRIVATE $<$<NOT:$<CONFIG:Debug>>:NB_COMPACT_ASSERTIONS>)
 
     TARGET_LINK_LIBRARIES (${NAME} PRIVATE ${SHARED_LIBRARY_TARGET})
 
@@ -161,8 +200,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --python ${PYTHON_VERSION} --all-extras
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv run pybind11-stubgen -o . "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" # generate stubs in same dir as binaries
-                            COMMAND find "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_GROUP}" -type f -name "*.pyi" -exec sed -i "s/: \\\\.\\\\.\\\\./: typing.Any/g" {} + # crudely fix broken stubs; need to escape \\
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && env _PYTHON_HOST_PLATFORM="${PLATFORM}" uv build
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"
@@ -187,10 +225,28 @@ ENDFUNCTION ()
 
 ## Dependencies
 
-### Pybind11
+### Nanobind
 
-SET (PYBIND11_NOPYTHON ON)
-FIND_PACKAGE (pybind11 2.12.0 REQUIRED)
+INCLUDE (FetchContent)
+
+FetchContent_Declare (
+    nanobind
+    GIT_REPOSITORY https://github.com/wjakob/nanobind.git
+    GIT_TAG v2.9.2
+    GIT_SHALLOW TRUE
+)
+
+# Only nanobind's sources are needed. Its own CMake project resolves a single
+# interpreter, whereas the bindings are built once per supported python version,
+# so the runtime library is assembled per version by NB_ADD_LIBRARY below.
+FetchContent_GetProperties (nanobind)
+IF (NOT nanobind_POPULATED)
+    FetchContent_Populate (nanobind)
+ENDIF ()
+
+# `nb_combined.cpp` is nanobind's officially supported single-translation-unit
+# amalgamation, which keeps this list correct across nanobind upgrades.
+SET (NANOBIND_SOURCES "${nanobind_SOURCE_DIR}/src/nb_combined.cpp")
 
 ### Python
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -96,6 +96,9 @@ FUNCTION (NB_ADD_LIBRARY version)
     TARGET_COMPILE_FEATURES (${target} PUBLIC cxx_std_17)
     # Python's C API type-puns heavily.
     TARGET_COMPILE_OPTIONS (${target} PRIVATE "-fno-strict-aliasing")
+    # Trade nanobind's verbose assertion messages for a smaller binary. The macro is only read by
+    # nanobind's own sources, so this is the target that actually needs it.
+    TARGET_COMPILE_DEFINITIONS (${target} PRIVATE $<$<NOT:$<CONFIG:Debug>>:NB_COMPACT_ASSERTIONS>)
     SET_TARGET_PROPERTIES (${target} PROPERTIES
                           POSITION_INDEPENDENT_CODE ON
                           C_VISIBILITY_PRESET hidden
@@ -200,7 +203,7 @@ FUNCTION (PY_ADD_PACKAGE_DIRECTORY NAME)
                             COMMAND cp "${CMAKE_SOURCE_DIR}/lib/${LIBRARY_TARGET}.*${EXTENSION}*.so" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/${PROJECT_PATH}/"
                             COMMAND cp "${CMAKE_CURRENT_SOURCE_DIR}/README.md" "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/README.md"
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && uv sync --python ${PYTHON_VERSION} --all-extras
-                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}" # generate stubs in same dir as binaries
+                            COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}" && uv run --project "${NAME}" python -m nanobind.stubgen -m "${PROJECT_GROUP}.${PROJECT_SUBGROUP}" -r -M "${NAME}/${PROJECT_PATH}/py.typed" -O "${NAME}/${PROJECT_PATH}" # generate stubs in same dir as binaries
                             COMMAND cd "${CMAKE_CURRENT_BINARY_DIR}/${NAME}" && env _PYTHON_HOST_PLATFORM="${PLATFORM}" uv build
                             COMMAND mkdir -p "${CMAKE_CURRENT_BINARY_DIR}/dist"
                             COMMAND cp "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/dist/*" "${CMAKE_CURRENT_BINARY_DIR}/dist"

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy.cxx
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy.cxx
@@ -1,12 +1,24 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkitSimulationPy/Utility/ArrayCasting.hpp>
+#include <OpenSpaceToolkitSimulationPy/Utility/EigenSequenceCasting.hpp>
 #include <OpenSpaceToolkitSimulationPy/Utility/ShiftToString.hpp>
-#include <pybind11/eigen.h>
-#include <pybind11/numpy.h>
-#include <pybind11/operators.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/eigen/dense.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/ndarray.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/set.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/unordered_set.h>
+#include <nanobind/stl/vector.h>
 
 #include <OpenSpaceToolkitSimulationPy/Component.cpp>
 #include <OpenSpaceToolkitSimulationPy/Entity.cpp>
@@ -14,7 +26,7 @@
 #include <OpenSpaceToolkitSimulationPy/Simulator.cpp>
 #include <OpenSpaceToolkitSimulationPy/Utility/ComponentHolder.cpp>
 
-PYBIND11_MODULE(OpenSpaceToolkitSimulationPy, m)
+NB_MODULE(OpenSpaceToolkitSimulationPy, m)
 {
     // Add optional docstring for package OpenSpaceToolkitSimulationPy
     m.doc() = "Elementary space systems blocks for Simulation in Open Space Toolkit.";

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Component.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Component.cpp
@@ -1,13 +1,14 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Simulation/Component.hpp>
+#include <OpenSpaceToolkitSimulationPy/Utility/ComponentHolderMixin.hpp>
 
 #include <OpenSpaceToolkitSimulationPy/Component/Geometry.cpp>
 #include <OpenSpaceToolkitSimulationPy/Component/State.cpp>
 
-inline void OpenSpaceToolkitSimulationPy_Component(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Component(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -27,7 +28,7 @@ inline void OpenSpaceToolkitSimulationPy_Component(pybind11::module& aModule)
     using ostk::simulation::utility::ComponentHolder;
 
     {
-        class_<Component, Entity, ComponentHolder, Shared<Component>> component_class(
+        class_<Component, Entity> component_class(
             aModule,
             "Component",
             R"doc(
@@ -38,6 +39,9 @@ inline void OpenSpaceToolkitSimulationPy_Component(pybind11::module& aModule)
                 and reference frame management.
             )doc"
         );
+
+        // nanobind supports single inheritance only, so the ComponentHolder mixin is folded in.
+        OpenSpaceToolkitSimulationPy_Utility_ComponentHolder_AddMethods(component_class);
 
         component_class
             .def(

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Component/Geometry.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Component/Geometry.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Simulation/Component/Geometry.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Component_Geometry(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Component_Geometry(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -21,7 +21,7 @@ inline void OpenSpaceToolkitSimulationPy_Component_Geometry(pybind11::module& aM
     using ostk::simulation::component::Geometry;
     using ostk::simulation::component::GeometryConfiguration;
 
-    class_<Geometry, Shared<Geometry>>(
+    class_<Geometry>(
         aModule,
         "Geometry",
         R"doc(
@@ -185,7 +185,7 @@ inline void OpenSpaceToolkitSimulationPy_Component_Geometry(pybind11::module& aM
         .def(
             "access_composite",
             &Geometry::accessComposite,
-            return_value_policy::reference,
+            rv_policy::reference,
             R"doc(
                 Access the underlying composite geometry.
 

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Component/State.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Component/State.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Simulation/Component/State.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Component_State(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Component_State(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::simulation::component::State;
 

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Entity.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Entity.cpp
@@ -2,16 +2,16 @@
 
 #include <OpenSpaceToolkit/Simulation/Entity.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Entity(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Entity(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::type::Shared;
 
     using ostk::simulation::Entity;
 
     {
-        class_<Entity, Shared<Entity>>(
+        class_<Entity>(
             aModule,
             "Entity",
             R"doc(

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Satellite.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Satellite.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Simulation/Satellite.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Satellite(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Satellite(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -22,7 +22,7 @@ inline void OpenSpaceToolkitSimulationPy_Satellite(pybind11::module& aModule)
     using ostk::simulation::SatelliteConfiguration;
     using ostk::simulation::Simulator;
 
-    class_<Satellite, Component, Shared<Satellite>>(
+    class_<Satellite, Component>(
         aModule,
         "Satellite",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Simulator.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Simulator.cpp
@@ -2,9 +2,9 @@
 
 #include <OpenSpaceToolkit/Simulation/Simulator.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Simulator(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Simulator(nanobind::module_& aModule)
 {
-    using namespace pybind11;
+    using namespace nanobind;
 
     using ostk::core::container::Array;
     using ostk::core::type::Shared;
@@ -16,7 +16,7 @@ inline void OpenSpaceToolkitSimulationPy_Simulator(pybind11::module& aModule)
     using ostk::simulation::Simulator;
     using ostk::simulation::SimulatorConfiguration;
 
-    class_<Simulator, Shared<Simulator>>(
+    class_<Simulator>(
         aModule,
         "Simulator",
         R"doc(

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ArrayCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ArrayCasting.hpp
@@ -1,11 +1,23 @@
 /// Apache License 2.0
 
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/array.h>
+#include <nanobind/stl/complex.h>
+#include <nanobind/stl/map.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/pair.h>
+#include <nanobind/stl/set.h>
+#include <nanobind/stl/shared_ptr.h>
+#include <nanobind/stl/string.h>
+#include <nanobind/stl/tuple.h>
+#include <nanobind/stl/unique_ptr.h>
+#include <nanobind/stl/unordered_map.h>
+#include <nanobind/stl/unordered_set.h>
+#include <nanobind/stl/vector.h>
 
 #include <OpenSpaceToolkit/Core/Container/Array.hpp>
 
-namespace pybind11
+namespace nanobind
 {
 namespace detail
 {
@@ -18,4 +30,4 @@ struct type_caster<Array<T>> : list_caster<Array<T>, T>
 };
 
 }  // namespace detail
-}  // namespace pybind11
+}  // namespace nanobind

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ComponentHolder.cpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ComponentHolder.cpp
@@ -1,16 +1,15 @@
 /// Apache License 2.0
 
 #include <OpenSpaceToolkit/Simulation/Utility/ComponentHolder.hpp>
+#include <OpenSpaceToolkitSimulationPy/Utility/ComponentHolderMixin.hpp>
 
-inline void OpenSpaceToolkitSimulationPy_Utility_ComponentHolder(pybind11::module& aModule)
+inline void OpenSpaceToolkitSimulationPy_Utility_ComponentHolder(nanobind::module_& aModule)
 {
-    using namespace pybind11;
-
-    using ostk::core::type::Shared;
+    using namespace nanobind;
 
     using ostk::simulation::utility::ComponentHolder;
 
-    class_<ComponentHolder, Shared<ComponentHolder>>(
+    class_<ComponentHolder> componentHolderClass(
         aModule,
         "ComponentHolder",
         R"doc(
@@ -19,161 +18,7 @@ inline void OpenSpaceToolkitSimulationPy_Utility_ComponentHolder(pybind11::modul
             ComponentHolder enables storage and retrieval of child components, supporting both flat
             and hierarchical component organization with path-based access.
         )doc"
-    )
+    );
 
-        .def(
-            "has_component_with_id",
-            &ComponentHolder::hasComponentWithId,
-            R"doc(
-                Check if a component with the given ID exists.
-
-                Args:
-                    id (str): The component ID to search for.
-
-                Returns:
-                    bool: True if a component with the ID exists, False otherwise.
-
-                Example:
-                    >>> holder.has_component_with_id("sensor-1")
-                    True
-            )doc"
-        )
-
-        .def(
-            "has_component_with_name",
-            &ComponentHolder::hasComponentWithName,
-            R"doc(
-                Check if a component with the given name exists.
-
-                Args:
-                    name (str): The component name to search for.
-
-                Returns:
-                    bool: True if a component with the name exists, False otherwise.
-
-                Example:
-                    >>> holder.has_component_with_name("Main Sensor")
-                    True
-            )doc"
-        )
-
-        .def(
-            "has_component_at",
-            &ComponentHolder::hasComponentAt,
-            R"doc(
-                Check if a component exists at the given path.
-
-                Args:
-                    path (str): The component path (e.g., "parent/child").
-
-                Returns:
-                    bool: True if a component exists at the path, False otherwise.
-
-                Example:
-                    >>> holder.has_component_at("payload/sensor-1")
-                    True
-            )doc"
-        )
-
-        .def(
-            "access_components",
-            &ComponentHolder::accessComponents,
-            R"doc(
-                Access all child components.
-
-                Returns:
-                    list: Array of all child components.
-
-                Example:
-                    >>> components = holder.access_components()
-                    >>> len(components)
-                    3
-            )doc"
-        )
-
-        .def(
-            "access_component_with_id",
-            &ComponentHolder::accessComponentWithId,
-            R"doc(
-                Access a component by its ID.
-
-                Args:
-                    id (str): The component ID.
-
-                Returns:
-                    Component: The component with the specified ID.
-
-                Example:
-                    >>> component = holder.access_component_with_id("sensor-1")
-            )doc"
-        )
-
-        .def(
-            "access_component_with_name",
-            &ComponentHolder::accessComponentWithName,
-            R"doc(
-                Access a component by its name.
-
-                Args:
-                    name (str): The component name.
-
-                Returns:
-                    Component: The component with the specified name.
-
-                Example:
-                    >>> component = holder.access_component_with_name("Main Sensor")
-            )doc"
-        )
-
-        .def(
-            "access_components_with_tag",
-            &ComponentHolder::accessComponentsWithTag,
-            R"doc(
-                Access all components with a specific tag.
-
-                Args:
-                    tag (str): The tag to filter by.
-
-                Returns:
-                    list: Array of components with the specified tag.
-
-                Example:
-                    >>> sensors = holder.access_components_with_tag("sensor")
-                    >>> len(sensors)
-                    2
-            )doc"
-        )
-
-        .def(
-            "access_component_at",
-            &ComponentHolder::accessComponentAt,
-            R"doc(
-                Access a component at a given path.
-
-                Args:
-                    path (str): The component path (e.g., "parent/child").
-
-                Returns:
-                    Component: The component at the specified path.
-
-                Example:
-                    >>> component = holder.access_component_at("payload/sensor-1")
-            )doc"
-        )
-
-        .def(
-            "add_component",
-            &ComponentHolder::addComponent,
-            R"doc(
-                Add a child component.
-
-                Args:
-                    component (Component): The component to add.
-
-                Example:
-                    >>> holder.add_component(sensor)
-            )doc"
-        )
-
-        ;
+    OpenSpaceToolkitSimulationPy_Utility_ComponentHolder_AddMethods(componentHolderClass);
 }

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ComponentHolderMixin.hpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/ComponentHolderMixin.hpp
@@ -1,0 +1,189 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkitSimulationPy_Utility_ComponentHolderMixin__
+#define __OpenSpaceToolkitSimulationPy_Utility_ComponentHolderMixin__
+
+#include <OpenSpaceToolkit/Simulation/Utility/ComponentHolder.hpp>
+#include <nanobind/nanobind.h>
+
+/// @brief                      Add ComponentHolder's interface to a class deriving from it.
+///
+///                             nanobind supports single inheritance only, so a class cannot declare
+///                             both its own base and this mixin. It takes the methods directly
+///                             instead, which is why they live in a header rather than alongside
+///                             the ComponentHolder binding.
+
+template <class ClassType>
+inline void OpenSpaceToolkitSimulationPy_Utility_ComponentHolder_AddMethods(ClassType& aClass)
+{
+    using namespace nanobind;
+
+    using ostk::simulation::utility::ComponentHolder;
+
+    aClass
+
+        .def(
+            "has_component_with_id",
+            &ComponentHolder::hasComponentWithId,
+            R"doc(
+                Check if a component with the given ID exists.
+
+                Args:
+                    id (str): The component ID to search for.
+
+                Returns:
+                    bool: True if a component with the ID exists, False otherwise.
+
+                Example:
+                    >>> holder.has_component_with_id("sensor-1")
+                    True
+            )doc"
+        )
+
+        .def(
+            "has_component_with_name",
+            &ComponentHolder::hasComponentWithName,
+            R"doc(
+                Check if a component with the given name exists.
+
+                Args:
+                    name (str): The component name to search for.
+
+                Returns:
+                    bool: True if a component with the name exists, False otherwise.
+
+                Example:
+                    >>> holder.has_component_with_name("Main Sensor")
+                    True
+            )doc"
+        )
+
+        .def(
+            "has_component_at",
+            &ComponentHolder::hasComponentAt,
+            R"doc(
+                Check if a component exists at the given path.
+
+                Args:
+                    path (str): The component path (e.g., "parent/child").
+
+                Returns:
+                    bool: True if a component exists at the path, False otherwise.
+
+                Example:
+                    >>> holder.has_component_at("payload/sensor-1")
+                    True
+            )doc"
+        )
+
+        .def(
+            "access_components",
+            &ComponentHolder::accessComponents,
+            R"doc(
+                Access all child components.
+
+                Returns:
+                    list: Array of all child components.
+
+                Example:
+                    >>> components = holder.access_components()
+                    >>> len(components)
+                    3
+            )doc"
+        )
+
+        .def(
+            "access_component_with_id",
+            &ComponentHolder::accessComponentWithId,
+            R"doc(
+                Access a component by its ID.
+
+                Args:
+                    id (str): The component ID.
+
+                Returns:
+                    Component: The component with the specified ID.
+
+                Example:
+                    >>> component = holder.access_component_with_id("sensor-1")
+            )doc"
+        )
+
+        .def(
+            "access_component_with_name",
+            &ComponentHolder::accessComponentWithName,
+            R"doc(
+                Access a component by its name.
+
+                Args:
+                    name (str): The component name.
+
+                Returns:
+                    Component: The component with the specified name.
+
+                Example:
+                    >>> component = holder.access_component_with_name("Main Sensor")
+            )doc"
+        )
+
+        .def(
+            "access_components_with_tag",
+            &ComponentHolder::accessComponentsWithTag,
+            R"doc(
+                Access all components with a specific tag.
+
+                Args:
+                    tag (str): The tag to filter by.
+
+                Returns:
+                    list: Array of components with the specified tag.
+
+                Example:
+                    >>> sensors = holder.access_components_with_tag("sensor")
+                    >>> len(sensors)
+                    2
+            )doc"
+        )
+
+        .def(
+            "access_component_at",
+            &ComponentHolder::accessComponentAt,
+            R"doc(
+                Access a component at a given path.
+
+                Args:
+                    path (str): The component path (e.g., "parent/child").
+
+                Returns:
+                    Component: The component at the specified path.
+
+                Example:
+                    >>> component = holder.access_component_at("payload/sensor-1")
+            )doc"
+        )
+
+        .def(
+            "add_component",
+            // `self` is taken as a Shared<> so that `Component::addComponent`'s
+            // `shared_from_this()` has an owner under nanobind, which does not hold bound
+            // instances in a shared_ptr the way pybind11 did.
+            [](const ostk::core::type::Shared<typename ClassType::Type>& aHolderSPtr,
+               const ostk::core::type::Shared<ostk::simulation::Component>& aComponentSPtr)
+            {
+                aHolderSPtr->addComponent(aComponentSPtr);
+            },
+            R"doc(
+                Add a child component.
+
+                Args:
+                    component (Component): The component to add.
+
+                Example:
+                    >>> holder.add_component(sensor)
+            )doc"
+        )
+
+        ;
+}
+
+#endif

--- a/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/EigenSequenceCasting.hpp
+++ b/bindings/python/src/OpenSpaceToolkitSimulationPy/Utility/EigenSequenceCasting.hpp
@@ -1,0 +1,147 @@
+/// Apache License 2.0
+
+#ifndef __OpenSpaceToolkitPy_Utility_EigenSequenceCasting__
+#define __OpenSpaceToolkitPy_Utility_EigenSequenceCasting__
+
+#include <nanobind/eigen/dense.h>
+#include <nanobind/nanobind.h>
+
+#include <Eigen/Dense>
+
+/// @brief                      Accept any python sequence where a dense Eigen vector or matrix is expected.
+///
+///                             pybind11's Eigen support converted lists and tuples on the caller's behalf.
+///                             nanobind's only accepts objects exposing DLPack or the buffer protocol, so
+///                             `Position.meters([1.0, 2.0, 3.0], frame)` would stop working. These casters
+///                             run nanobind's own conversion first and fall back to `numpy.asarray` for
+///                             anything else, restoring the previous behaviour.
+///
+///                             This header must be included before any binding code that mentions one of
+///                             the types below, since a specialization may not follow its first use.
+
+namespace nanobind
+{
+namespace detail
+{
+
+template <class MatrixType>
+struct EigenSequenceCaster
+{
+    using Scalar = typename MatrixType::Scalar;
+
+    /// @brief                  A layout-identical Eigen::Array.
+    ///
+    ///                         This specialization replaces nanobind's own dense caster for MatrixType,
+    ///                         which then can no longer be named. Eigen::Array is a distinct type with
+    ///                         the same storage, so nanobind's caster stays reachable through it.
+
+    using Bridge = Eigen::Array<
+        Scalar,
+        MatrixType::RowsAtCompileTime,
+        MatrixType::ColsAtCompileTime,
+        MatrixType::Options,
+        MatrixType::MaxRowsAtCompileTime,
+        MatrixType::MaxColsAtCompileTime>;
+
+    using BridgeCaster = make_caster<Bridge>;
+
+    NB_TYPE_CASTER(MatrixType, BridgeCaster::Name)
+
+    bool from_python(handle aSource, uint8_t someFlags, cleanup_list* aCleanupList) noexcept
+    {
+        BridgeCaster caster;
+
+        if (caster.from_python(aSource, someFlags, aCleanupList))
+        {
+            value = caster.value.matrix();
+
+            return true;
+        }
+
+        if ((someFlags & static_cast<uint8_t>(cast_flags::convert)) == 0)
+        {
+            return false;
+        }
+
+        // Turn the sequence into an array of the right scalar type. Asking for the dtype matters:
+        // a list holding an `ostk::core::type::Real` (or any object with __float__) would otherwise
+        // come back with object dtype, which nanobind rejects.
+
+        object array;
+
+        try
+        {
+            array = module_::import_("numpy").attr("asarray")(aSource, numpyDtype());
+        }
+        catch (...)
+        {
+            return false;
+        }
+
+        if (!caster.from_python(array.ptr(), someFlags, aCleanupList))
+        {
+            return false;
+        }
+
+        // `caster.value` views `array`, which is alive for the duration of this copy.
+
+        value = caster.value.matrix();
+
+        return true;
+    }
+
+    /// @brief                  The numpy dtype string matching Scalar, e.g. "f8" for a double.
+
+    static const char* numpyDtype() noexcept
+    {
+        static_assert(sizeof(Scalar) <= 9, "Unsupported scalar size.");
+
+        static const char dtype[3] = {
+            std::is_floating_point_v<Scalar> ? 'f' : (std::is_signed_v<Scalar> ? 'i' : 'u'),
+            static_cast<char>('0' + sizeof(Scalar)),
+            '\0',
+        };
+
+        return dtype;
+    }
+
+    static handle from_cpp(const MatrixType& aMatrix, rv_policy, cleanup_list* aCleanupList) noexcept
+    {
+        // The bridge is a fresh copy, so it can always be moved from. No binding in this project
+        // returns a plain Eigen value under a view policy, which would need the original storage.
+
+        return BridgeCaster::from_cpp(Bridge(aMatrix.array()), rv_policy::move, aCleanupList);
+    }
+};
+
+#define OSTK_EIGEN_SEQUENCE_CASTER(...)                                \
+    template <>                                                        \
+    struct type_caster<__VA_ARGS__> : EigenSequenceCaster<__VA_ARGS__> \
+    {                                                                  \
+    };
+
+// Matches the aliases in open-space-toolkit-mathematics' Object/Vector.hpp.
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector2i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector3i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector4i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::VectorXi)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector2d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector3d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Vector4d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix<double, 6, 1>)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::VectorXd)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix2i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix3i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix4i)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::MatrixXi)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix2d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix3d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::Matrix4d)
+OSTK_EIGEN_SEQUENCE_CASTER(Eigen::MatrixXd)
+
+#undef OSTK_EIGEN_SEQUENCE_CASTER
+
+}  // namespace detail
+}  // namespace nanobind
+
+#endif

--- a/bindings/python/tools/python/pyproject.toml.in
+++ b/bindings/python/tools/python/pyproject.toml.in
@@ -31,7 +31,7 @@ dependencies = [
 
 [project.optional-dependencies]
 prebuild = [
-    "pybind11-stubgen"
+    "nanobind==2.9.2"
 ]
 test = [
     "pytest"
@@ -50,5 +50,5 @@ ext-modules = [
 include = ["ostk.simulation", "ostk.simulation.*"]
 
 [tool.setuptools.package-data]
-"ostk.simulation" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so"]
+"ostk.simulation" = ["${SHARED_LIBRARY_TARGET}.${PROJECT_VERSION_MAJOR}", "${LIBRARY_TARGET}.*${EXTENSION}*.so", "*.pyi", "py.typed"]
 "*" = ["*/data/*"]


### PR DESCRIPTION
Replaces pybind11 with [nanobind](https://github.com/wjakob/nanobind) as the Python binding layer. Completes a six-repository stack, starting with open-space-collective/open-space-toolkit-core#211.

nanobind is a from-scratch rewrite of pybind11 by the same author with a much leaner call path. Measured on Core's bindings — same commit, same C++ library, release build — it is **6.62x faster** per call at the geometric mean; end to end on the astrodynamics stack it is **5.18x** with a **44% smaller** extension module.

## What needed real work

Simulation's bindings are small, so most of the translation is mechanical. Two things are not:

- **`Component` no longer declares `ComponentHolder` as a second base class.** nanobind supports single inheritance only, so the mixin's method definitions move into `Utility/ComponentHolderMixin.hpp` and `Component` pulls them in directly. `ComponentHolder` is still bound and still carries the same methods, and every call site is unaffected — only `isinstance(component, ComponentHolder)` changes.
- **`add_component` takes `self` as a `Shared<>`.** `Component` derives from `std::enable_shared_from_this`; pybind11 held every instance in a `Shared<>` so `shared_from_this()` always had an owner, whereas nanobind owns instances directly and registers the weak reference only when a value is converted to a `shared_ptr`.

## `Utility/EigenSequenceCasting.hpp` (new)

This restores an API that would otherwise break silently. pybind11 converted any Python sequence for a dense Eigen argument; nanobind only accepts objects exposing DLPack or the buffer protocol, so passing a list would have started raising `TypeError`.

## Build and ordering

nanobind is fetched with `FetchContent`, so **no development image change is needed**. Pinned to **v2.9.2**: v3.x requires Python 3.10 and this project still ships 3.9 wheels.

pybind11 and nanobind keep **separate type registries**, and a nanobind module fails at *import* against a pybind11 dependency. This must be released last.

## Testing

18/18 Python tests pass against a nanobind-built rest of the toolkit.


---

## Release order

pybind11 and nanobind keep separate type registries, and a nanobind module fails at **import** against a pybind11 dependency — not merely at call time. These must therefore be merged and released strictly in dependency order:

1. open-space-collective/open-space-toolkit-core#211
2. open-space-collective/open-space-toolkit-io#126
3. open-space-collective/open-space-toolkit-mathematics#201
4. open-space-collective/open-space-toolkit-physics#399
5. open-space-collective/open-space-toolkit-astrodynamics#710
6. open-space-collective/open-space-toolkit-simulation#96

Until the dependency above it is on PyPI, building a repository in this stack locally needs the previously built wheels supplied to `uv` (e.g. `UV_FIND_LINKS=<wheelhouse>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Migrated the Python bindings from pybind11 to nanobind.
  - Preserved existing module functionality and Python APIs while updating the underlying binding implementation.
  - Improved support for Python sequence conversion to Eigen vectors and matrices.
  - Maintained and expanded generated type stub packaging for improved editor and type-checking support.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->